### PR TITLE
Fixing typo in repo name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dvcrn/maskedemailcli
+module github.com/dvcrn/maskedemail-cli
 
 go 1.16
 


### PR DESCRIPTION
Fixing this issue https://github.com/dvcrn/maskedemail-cli/issues/1