### PR TITLE
Read -token, -accountid, -appname from environment variables

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,9 +10,9 @@ import (
 	"text/tabwriter"
 )
 
-var flagAppname = flag.String("appname", "maskedemail-cli", "the appname to identify the creator")
-var flagToken = flag.String("token", "", "the token to authenticate with")
-var flagAccountID = flag.String("accountid", "", "fastmail account id")
+var flagAppname = flag.String("appname", os.Getenv("MASKEDEMAIL_APPNAME"), "the appname to identify the creator")
+var flagToken = flag.String("token", os.Getenv("MASKEDEMAIL_TOKEN"), "the token to authenticate with")
+var flagAccountID = flag.String("accountid", os.Getenv("MASKEDEMAIL_ACCOUNTID"), "fastmail account id")
 var action actionType = actionTypeUnknown
 
 type actionType string
@@ -24,6 +24,7 @@ const (
 	actionTypeDisable = "disable"
 	actionTypeEnable  = "enable"
 	actionTypeList    = "list"
+	defaultAppname = "maskedemail-cli"
 )
 
 func init() {
@@ -51,6 +52,10 @@ func init() {
 		log.Println("-token flag is not set")
 		flag.Usage()
 		os.Exit(1)
+	}
+
+	if *flagAppname == "" {
+		*flagAppname = defaultAppname
 	}
 
 	switch strings.ToLower(flag.Arg(0)) {


### PR DESCRIPTION
Add support for reading mentioned CLI flags as environment variables. The proposed names are:

MASKEDEMAIL_TOKEN
MASKEDEMAIL_ACCOUNTID
MASKEDEMAIL_APPNAME

CLI flags take precedence over environment variables.

If there's anything that needs to be changed, please let me know.

Related issue: #6 