### PR TITLE
v2.0.0 if you want it?

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,61 @@ GO_SRC := $(wildcard ./*.go ./pkg/*.go)
 INSTALL_DIR := ${HOME}/.local/bin
 TARGET_BIN := maskedemail-cli
 
+# taken from: https://gist.github.com/grihabor/4a750b9d82c9aa55d5276bd5503829be
+# Version Start
+USE_VERSION := false
+# If this isn't a git repo or the repo has no tags, git describe will return non-zero
+ifeq ($(shell git describe > /dev/null 2>&1 ; echo $$?), 0)
+	USE_VERSION		   := true
+	DESCRIBE           := $(shell git describe --match "v*" --always --tags --dirty)
+	DESCRIBE_PARTS     := $(subst -, ,$(DESCRIBE))
+
+	VERSION_TAG        := $(word 1,$(DESCRIBE_PARTS))
+	COMMITS_SINCE_TAG  := $(word 2,$(DESCRIBE_PARTS))
+	DIRTY              := $(word 4,$(DESCRIBE_PARTS))
+	# prepend a dash to dirty if its set
+	ifeq ($(DIRTY), dirty)
+		DIRTY := -$(DIRTY)
+	endif
+
+	VERSION            := $(subst v,,$(VERSION_TAG))
+	VERSION_PARTS      := $(subst ., ,$(VERSION))
+
+	MAJOR              := $(word 1,$(VERSION_PARTS))
+	MINOR              := $(word 2,$(VERSION_PARTS))
+	PATCH              := $(word 3,$(VERSION_PARTS))
+
+	NEXT_MAJOR         := $(shell echo $$(($(MAJOR)+1)))
+	NEXT_MINOR         := $(shell echo $$(($(MINOR)+1)))
+	NEXT_PATCH          = $(shell echo $$(($(PATCH)+$(COMMITS_SINCE_TAG))))
+
+	ifeq ($(strip $(COMMITS_SINCE_TAG)),)
+	CURRENT_VERSION_PATCH := $(MAJOR).$(MINOR).$(PATCH)
+	CURRENT_VERSION_MINOR := $(CURRENT_VERSION_PATCH)
+	CURRENT_VERSION_MAJOR := $(CURRENT_VERSION_PATCH)
+	else
+	CURRENT_VERSION_PATCH := $(MAJOR).$(MINOR).$(NEXT_PATCH)
+	CURRENT_VERSION_MINOR := $(MAJOR).$(NEXT_MINOR).0
+	CURRENT_VERSION_MAJOR := $(NEXT_MAJOR).0.0
+	endif
+
+	DATE                = $(shell date +'%Y%m%d')
+	TIME                = $(shell date +'%H%M%S')
+	COMMIT             := $(shell git rev-parse --short HEAD)
+	#AUTHOR             := $(firstword $(subst @, ,$(shell git show --format="%aE" $(COMMIT))))
+	#BRANCH_NAME        := $(shell git rev-parse --abbrev-ref HEAD)
+
+	# TAG_MESSAGE         = "$(TIME) $(DATE) $(AUTHOR) $(BRANCH_NAME)"
+	# COMMIT_MESSAGE     := $(shell git log --format=%B -n 1 $(COMMIT))
+
+	# CURRENT_TAG_PATCH  := "v$(CURRENT_VERSION_PATCH)"
+	# CURRENT_TAG_MINOR  := "v$(CURRENT_VERSION_MINOR)"
+	# CURRENT_TAG_MAJOR  := "v$(CURRENT_VERSION_MAJOR)"
+endif
+# Version End
+
+# set a default build version to PATCH if nothing specified
+all: BUILD_VERSION = $(CURRENT_VERSION_PATCH)
 all: build
 
 install: ${INSTALL_DIR}/${TARGET_BIN}
@@ -15,8 +70,34 @@ build: bin/${TARGET_BIN}
 
 bin/%: ${GO_SRC}
 	mkdir bin/ &> /dev/null || true
+
+ifeq ($(USE_VERSION),true)
+# version is based on a git tag "vX.Y.Z" existing
+# if such a tag does not exist, empty value will be passed
+	@echo "Building version $(BUILD_VERSION)-$(COMMIT)$(DIRTY) of application:"
+	go build -ldflags "-X 'main.buildVersion=$(BUILD_VERSION)' -X 'main.buildCommit=$(COMMIT)$(DIRTY)'" -o $@
+else
+	@echo "Building application:"
 	go build -o $@
+endif
 
 .PHONY: clean
 clean:
 	rm -rf bin/
+
+# # --- Version commands ---
+# these need to be AFTER the all recipe or otherwise BUILD_VERSION will get set even if those are not specified
+.PHONY: version
+version: version-patch
+
+.PHONY: version-patch
+version-patch: BUILD_VERSION = $(CURRENT_VERSION_PATCH)
+version-patch: build
+
+.PHONY: version-minor
+version-minor: BUILD_VERSION = $(CURRENT_VERSION_MINOR)
+version-minor: build
+
+.PHONY: version-major
+version-major: BUILD_VERSION = $(CURRENT_VERSION_MAJOR)
+version-major: build

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ go install github.com/dvcrn/maskedemail-cli@latest
 ```
 
 ### Authentication
-You'll need to [create a FastMail API token](https://beta.fastmail.com/settings/security/tokens).
+You'll need to [create a FastMail API token](https://app.fastmail.com/settings/security/tokens).
 
 > **🔒 The only necessary scope is "Masked Email".**
 >
@@ -36,10 +36,12 @@ Flags:
       the appname to identify the creator (or MASKEDEMAIL_APPNAME env) (default: maskedemail-cli)
   -token string
       the token to authenticate with (or MASKEDEMAIL_TOKEN env)
+  -version
+      display the version of maskedemail-cli
 
 Commands:
   maskedemail-cli create [-domain "<domain>"] [-desc "<description>"] [-enabled=true|false (default true)]
-  maskedemail-cli list [-show-deleted (default false)]
+  maskedemail-cli list [-show-deleted] [-all-fields]
   maskedemail-cli enable <maskedemail>
   maskedemail-cli disable <maskedemail>
   maskedemail-cli delete <maskedemail>
@@ -50,16 +52,18 @@ Commands:
 Example:
 
 ```
-$ maskedemail-cli -token abcdef12345 create  -domain "facebook.com" -desc "Facebook"
+$ maskedemail-cli -token abcdef12345 create -domain "facebook.com" -desc "Facebook"
 $ maskedemail-cli -token abcdef12345 enable 123@mydomain.com
 $ maskedemail-cli -token abcdef12345 disable 123@mydomain.com
 
 $ maskedemail-cli -token abcdef12345 list
-Masked Email        For Domain     Description   State       Last Email At           Created At
-123@mydomain.com    facebook.com   Facebook      disabled    2022-08-09T07:49:43Z    2022-07-02T06:34:21Z
+Masked Email        For Domain     Description   State
+123@mydomain.com    facebook.com   Facebook      disabled
 ```
 
 ## Other resources and things powered by this CLI 
+
+_Note that these are based on an earlier version of the CLI._
 
 - [Siri Shortcut](https://www.icloud.com/shortcuts/973a2453b95d4dab97db950260283f4d) to disable the masked email of the currently selected message in Apple Mail on macOS
 - [maskedemail-js](https://github.com/dvcrn/maskedemail-js): Node package ready to import, backed by this CLI compiled to wasm

--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ Flags:
       the appname to identify the creator (or MASKEDEMAIL_APPNAME env) (default: maskedemail-cli)
   -token string
       the token to authenticate with (or MASKEDEMAIL_TOKEN env)
-  -version
-      display the version of maskedemail-cli
 
 Commands:
   maskedemail-cli create [-domain "<domain>"] [-desc "<description>"] [-enabled=true|false (default true)]
@@ -47,6 +45,7 @@ Commands:
   maskedemail-cli delete <maskedemail>
   maskedemail-cli update -email <maskedemail> [-domain "<domain>"] [-desc "<description>"]
   maskedemail-cli session
+  maskedemail-cli version
 ```
 
 Example:
@@ -61,7 +60,7 @@ Masked Email        For Domain     Description   State
 123@mydomain.com    facebook.com   Facebook      disabled
 ```
 
-## Other resources and things powered by this CLI 
+## Other resources and things powered by this CLI
 
 _Note that these are based on an earlier version of the CLI._
 

--- a/README.md
+++ b/README.md
@@ -34,28 +34,29 @@ Flags:
       fastmail account id (or MASKEDEMAIL_ACCOUNTID env)
   -appname string
       the appname to identify the creator (or MASKEDEMAIL_APPNAME env) (default: maskedemail-cli)
-  -show-deleted
-      when enabled even deleted emails are shown, (default: false)
   -token string
-      the token to authenticate with (or MASKEDEMAIL_TOKEN env) (default "example-token")
+      the token to authenticate with (or MASKEDEMAIL_TOKEN env)
 
 Commands:
-  maskedemail-cli create <domain> <description>
+  maskedemail-cli create [-domain "<domain>"] [-desc "<description>"] [-enabled=true|false (default true)]
+  maskedemail-cli list [-show-deleted (default false)]
   maskedemail-cli enable <maskedemail>
   maskedemail-cli disable <maskedemail>
+  maskedemail-cli delete <maskedemail>
+  maskedemail-cli update -email <maskedemail> [-domain "<domain>"] [-desc "<description>"]
   maskedemail-cli session
-  maskedemail-cli list
 ```
 
 Example:
 
 ```
-$ maskedemail-cli -token abcdef12345 create facebook.com "Facebook"
+$ maskedemail-cli -token abcdef12345 create  -domain "facebook.com" -desc "Facebook"
 $ maskedemail-cli -token abcdef12345 enable 123@mydomain.com
 $ maskedemail-cli -token abcdef12345 disable 123@mydomain.com
 
-$ maskedemail-cli -token abcdef12345 list | grep facebook
-123@mydomain.com    https://www.facebook.com    Facebook    disabled    2022-08-09T07:49:43Z    2022-07-02T06:34:21Z
+$ maskedemail-cli -token abcdef12345 list
+Masked Email        For Domain     Description   State       Last Email At           Created At
+123@mydomain.com    facebook.com   Facebook      disabled    2022-08-09T07:49:43Z    2022-07-02T06:34:21Z
 ```
 
 ## Other resources and things powered by this CLI 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Flags:
       the token to authenticate with (or MASKEDEMAIL_TOKEN env) (default "example-token")
 
 Commands:
-  maskedemail-cli create <domain>
+  maskedemail-cli create <domain> <description>
   maskedemail-cli enable <maskedemail>
   maskedemail-cli disable <maskedemail>
   maskedemail-cli session
@@ -50,12 +50,12 @@ Commands:
 Example:
 
 ```
-$ maskedemail-cli -token abcdef12345 create facebook.com
+$ maskedemail-cli -token abcdef12345 create facebook.com "Facebook"
 $ maskedemail-cli -token abcdef12345 enable 123@mydomain.com
 $ maskedemail-cli -token abcdef12345 disable 123@mydomain.com
 
 $ maskedemail-cli -token abcdef12345 list | grep facebook
-123@mydomain.com     https://www.facebook.com       disabled   2022-08-09T07:49:43Z
+123@mydomain.com    https://www.facebook.com    Facebook    disabled    2022-08-09T07:49:43Z    2022-07-02T06:34:21Z
 ```
 
 ## Other resources and things powered by this CLI 

--- a/main.go
+++ b/main.go
@@ -112,12 +112,6 @@ func init() {
 					defaultAppname, actionTypeSession)
 	}
 
-	// if len(flag.Args()) < 1 {
-	// 	log.Println("no argument given. currently supported: create, session, enable, disable, delete, update, list")
-	// 	flag.Usage()
-	// 	os.Exit(1)
-	// }
-
 	// CLI parameter have precedence over ENV variables
 	if *flagToken == "" {
 		envToken = os.Getenv(envTokenVarName)

--- a/main.go
+++ b/main.go
@@ -51,7 +51,6 @@ var buildCommit string = "n/a"
 
 // default / highest level flags
 var flagAppname = flag.String("appname", os.Getenv(envAppVarName), "the appname to identify the creator (or "+envAppVarName+" env) (default: "+defaultAppname+")")
-var flagVersion = flag.Bool(actionTypeVersion, false, "display the version of " + defaultAppname)
 var flagToken = flag.String(flagNameToken, "", "the token to authenticate with (or "+envTokenVarName+" env)")
 var flagAccountID = flag.String(flagNameAccountID, os.Getenv(envAccountIdVarName), "fastmail account id (or "+envAccountIdVarName+" env)")
 
@@ -72,10 +71,10 @@ var flagUpdateEmail = updateCmd.String(flagNameEmail, "", "masked email to updat
 var flagUpdateDomain = updateCmd.String(flagNameDomain, "", "domain for the masked email (optional, only updated if argument passed)")
 var flagUpdateDescription = updateCmd.String(flagNameDesc, "", "description for the masked email (optional, only updated if argument passed)")
 
-var args []string
-var action actionType = actionTypeUnknown
+var args        []string
+var action      actionType = actionTypeUnknown
 var commandArg  string
-var envToken string
+var envToken    string
 
 func isFlagPassed(set flag.FlagSet, name string) bool {
     found := false
@@ -130,6 +129,10 @@ func init() {
 		// session
 		fmt.Printf("  %s %s\n",
 					defaultAppname, actionTypeSession)
+
+		// version
+		fmt.Printf("  %s %s\n",
+					defaultAppname, actionTypeVersion)
 	}
 
 	// Check global arguments:
@@ -158,6 +161,9 @@ func init() {
 
 	switch commandArg {
 
+	case actionTypeVersion:
+		action = actionTypeVersion
+
 	case actionTypeCreate:
 		action = actionTypeCreate
 
@@ -183,16 +189,13 @@ func init() {
 
 func main() {
 
-	// handle version flag if passed
-	if *flagVersion {
-		fmt.Printf("version: %s\n", buildVersion)
-		fmt.Printf("commit: %s\n", buildCommit)
-		os.Exit(0)
-	}
-
 	client := pkg.NewClient(*flagToken, *flagAppname, "35c941ae")
 
 	switch action {
+
+	case actionTypeVersion:
+		fmt.Printf("version: %s\n", buildVersion)
+		fmt.Printf("commit: %s\n", buildCommit)
 
 	case actionTypeSession:
 		session, err := client.Session()

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ const (
 	actionTypeSession            = "session"
 	actionTypeDisable            = "disable"
 	actionTypeEnable             = "enable"
+	actionTypeDelete             = "delete"
 	actionTypeUpdateDomain       = "update domain"
 	actionTypeUpdateDescription  = "update desc"
 	actionTypeList               = "list"
@@ -55,6 +56,7 @@ func init() {
 		fmt.Println("  maskedemail-cli create [-domain \"<domain>\"] [-desc \"<description>\"] [-enabled=true|false (default: true)]")
 		fmt.Println("  maskedemail-cli enable <maskedemail>")
 		fmt.Println("  maskedemail-cli disable <maskedemail>")
+		fmt.Println("  maskedemail-cli delete <maskedemail>")
 		fmt.Println("  maskedemail-cli update domain <maskedemail> <domain>")
 		fmt.Println("  maskedemail-cli update desc <maskedemail> <description>")
 		fmt.Println("  maskedemail-cli session")
@@ -62,7 +64,7 @@ func init() {
 	}
 
 	if len(flag.Args()) < 1 {
-		log.Println("no argument given. currently supported: create, session, disable, enable, update domain, update desc")
+		log.Println("no argument given. currently supported: create, session, disable, enable, delete, update domain, update desc")
 		flag.Usage()
 		os.Exit(1)
 	}
@@ -95,6 +97,9 @@ func init() {
 
 	case "enable":
 		action = actionTypeEnable
+
+	case "delete":
+		action = actionTypeDelete
 
 	case "list":
 		action = actionTypeList
@@ -203,6 +208,23 @@ func main() {
 		}
 
 		fmt.Printf("enabled maskedemail: %s\n", flag.Arg(1))
+
+	case actionTypeDelete:
+		if flag.Arg(1) == "" {
+			log.Fatalln("Usage: delete <email>")
+		}
+
+		session, err := client.Session()
+		if err != nil {
+			log.Fatalf("initializing session: %v", err)
+		}
+
+		_, err = client.DeleteMaskedEmail(session, *flagAccountID, flag.Arg(1))
+		if err != nil {
+			log.Fatalf("err while deleting maskedemail: %v", err)
+		}
+
+		fmt.Printf("deleted maskedemail: %s\n", flag.Arg(1))
 
 	case actionTypeList:
 		session, err := client.Session()

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func init() {
 		flag.PrintDefaults()
 		fmt.Println("")
 		fmt.Println("Commands:")
-		fmt.Println("  maskedemail-cli create <domain>")
+		fmt.Println("  maskedemail-cli create <domain> <description>")
 		fmt.Println("  maskedemail-cli enable <maskedemail>")
 		fmt.Println("  maskedemail-cli disable <maskedemail>")
 		fmt.Println("  maskedemail-cli session")
@@ -131,8 +131,14 @@ func main() {
 		}
 
 	case actionTypeCreate:
-		if flag.Arg(1) == "" {
-			log.Fatalln("Usage: create <domain>")
+
+		if (len(flag.Args()) != 3) {
+			log.Fatalln("Usage: create <domain> <description>")
+		}
+
+		if (strings.TrimSpace(flag.Arg(1)) == "") && (strings.TrimSpace(flag.Arg(2)) == "") {
+			fmt.Println("Usage: create <domain> <description>")
+			log.Fatalln("At least one of <domain> and <description> are required")
 		}
 
 		session, err := client.Session()
@@ -140,7 +146,7 @@ func main() {
 			log.Fatalf("initializing session: %v", err)
 		}
 
-		createRes, err := client.CreateMaskedEmail(session, *flagAccountID, flag.Arg(1), true)
+		createRes, err := client.CreateMaskedEmail(session, *flagAccountID, flag.Arg(1), true, flag.Arg(2))
 		if err != nil {
 			log.Fatalf("err while creating maskedemail: %v", err)
 		}
@@ -193,13 +199,13 @@ func main() {
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
-		fmt.Fprintln(w, "Masked Email\tFor Domain\tState\tLast Email At\t")
+		fmt.Fprintln(w, "Masked Email\tFor Domain\tDescription\tState\tLast Email At\tCreated At")
 		for _, email := range maskedEmails {
 			if email.State == "deleted" && !*flagShowDeleted {
 				continue
 			}
 
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", email.Email, email.ForDomain, email.State, email.LastMessageAt)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", email.Email, email.ForDomain, email.Description, email.State, email.LastMessageAt, email.CreatedAt)
 		}
 		w.Flush()
 

--- a/main.go
+++ b/main.go
@@ -19,7 +19,10 @@ const envAccountIdVarName string = "MASKEDEMAIL_ACCOUNTID"
 var flagAppname = flag.String("appname", os.Getenv(envAppVarName), "the appname to identify the creator (or "+envAppVarName+" env) (default: maskedemail-cli)")
 var flagToken = flag.String("token", "", "the token to authenticate with (or "+envTokenVarName+" env)")
 var flagAccountID = flag.String("accountid", os.Getenv(envAccountIdVarName), "fastmail account id (or "+envAccountIdVarName+" env)")
-var flagShowDeleted = flag.Bool("show-deleted", false, "when enabled even deleted emails are shown, (default: false)")
+
+
+var listCmd = flag.NewFlagSet("list", flag.ExitOnError)
+var flagShowDeleted = listCmd.Bool("show-deleted", false, "when enabled even deleted emails are shown, (default: false)")
 
 var createCmd = flag.NewFlagSet("create", flag.ExitOnError)
 var flagCreateDomain = createCmd.String("domain", "", "domain for the masked email")
@@ -60,7 +63,7 @@ func init() {
 		fmt.Println("  maskedemail-cli update domain <maskedemail> <domain>")
 		fmt.Println("  maskedemail-cli update desc <maskedemail> <description>")
 		fmt.Println("  maskedemail-cli session")
-		fmt.Println("  maskedemail-cli list")
+		fmt.Println("  maskedemail-cli list [-show-deleted]")
 	}
 
 	if len(flag.Args()) < 1 {
@@ -157,7 +160,7 @@ func main() {
 		}
 
 	case actionTypeCreate:
-
+		// parse command-specific args
 		createCmd.Parse(os.Args[2:])
 
 		domain := strings.TrimSpace(*flagCreateDomain)
@@ -227,6 +230,9 @@ func main() {
 		fmt.Printf("deleted maskedemail: %s\n", flag.Arg(1))
 
 	case actionTypeList:
+		// parse command-specific args
+		listCmd.Parse(os.Args[2:])
+
 		session, err := client.Session()
 		if err != nil {
 			log.Fatalf("initializing session: %v", err)

--- a/main.go
+++ b/main.go
@@ -310,7 +310,7 @@ func main() {
 
 		// display header line
 		if *flagShowAllFields {
-			fmt.Fprintln(w, "ID\tMasked Email\tFor Domain\tDescription\tState\tLast Email At\tCreated At")
+			fmt.Fprintln(w, "Masked Email\tFor Domain\tDescription\tState\tID\tCreated At\tLast Email At")
 		} else {
 			fmt.Fprintln(w, "Masked Email\tFor Domain\tDescription\tState")
 		}
@@ -325,13 +325,13 @@ func main() {
 			// HACK: trim space here is for hack to deal with possible empty strings
 			if *flagShowAllFields {
 				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-					email.ID,
 					email.Email,
 					strings.TrimSpace(email.Domain),
 					strings.TrimSpace(email.Description),
 					email.State,
-					email.LastMessageAt,
-					email.CreatedAt)
+					email.ID,
+					email.CreatedAt,
+					email.LastMessageAt)
 			} else {
 				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
 					email.Email,

--- a/main.go
+++ b/main.go
@@ -224,7 +224,7 @@ func main() {
 			}
 
 			// HACK: trim space here is for hack to deal with possible empty strings
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", email.Email, strings.TrimSpace(email.ForDomain), strings.TrimSpace(email.Description), email.State, email.LastMessageAt, email.CreatedAt)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", email.Email, strings.TrimSpace(email.Domain), strings.TrimSpace(email.Description), email.State, email.LastMessageAt, email.CreatedAt)
 		}
 		w.Flush()
 
@@ -247,7 +247,7 @@ func main() {
 			log.Fatalf("initializing session: %v", err)
 		}
 
-		_, err = client.UpdateForDomain(session, *flagAccountID, maskedemail, domain)
+		_, err = client.UpdateDomain(session, *flagAccountID, maskedemail, domain)
 		if err != nil {
 			log.Fatalf("err updating maskedemail domain: %v", err)
 		}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,12 @@ import (
 	"github.com/dvcrn/maskedemail-cli/pkg"
 )
 
+// build info values get passed in from makefile via `-ldflags` argument to `go build`
+//   they only exist if within a git repo, otherwise use defaults below
+// version is based on a git tag "vX.Y.Z" existing
+var buildVersion string = "development"
+var buildCommit string = "n/a"
+
 const envTokenVarName string = "MASKEDEMAIL_TOKEN"
 const envAppVarName string = "MASKEDEMAIL_APPNAME"
 const envAccountIdVarName string = "MASKEDEMAIL_ACCOUNTID"
@@ -27,6 +33,7 @@ const flagNameShowDeleted string = "show-deleted"
 var flagAppname = flag.String("appname", os.Getenv(envAppVarName), "the appname to identify the creator (or "+envAppVarName+" env) (default: "+defaultAppname+")")
 var flagToken = flag.String("token", "", "the token to authenticate with (or "+envTokenVarName+" env)")
 var flagAccountID = flag.String("accountid", os.Getenv(envAccountIdVarName), "fastmail account id (or "+envAccountIdVarName+" env)")
+var flagVersion = flag.Bool("version", false, "display the version of " + defaultAppname)
 
 // flags for list command
 var listCmd = flag.NewFlagSet("list", flag.ExitOnError)
@@ -58,6 +65,7 @@ const (
 	actionTypeDelete             = "delete"
 	actionTypeUpdate             = "update"
 	actionTypeList               = "list"
+	actionTypeVersion            = "version"
 	defaultAppname               = "maskedemail-cli"
 )
 
@@ -153,9 +161,17 @@ func init() {
 }
 
 func main() {
+
+	if *flagVersion {
+		fmt.Printf("version: %s\n", buildVersion)
+		fmt.Printf("commit: %s\n", buildCommit)
+		os.Exit(0)
+	}
+
 	client := pkg.NewClient(*flagToken, *flagAppname, "35c941ae")
 
 	switch action {
+
 	case actionTypeSession:
 		session, err := client.Session()
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -252,7 +252,7 @@ func main() {
 			log.Fatalf("err updating maskedemail domain: %v", err)
 		}
 
-		fmt.Printf("updated domain to \"%s\" for maskedemail %s\n", domain, maskedemail)
+		fmt.Printf("updated domain to \"%s\" for %s\n", domain, maskedemail)
 
 	case actionTypeUpdateDescription:
 
@@ -278,7 +278,7 @@ func main() {
 			log.Fatalf("err updating maskedemail description: %v", err)
 		}
 
-		fmt.Printf("updated description to \"%s\" for maskedemail %s\n", description, maskedemail)
+		fmt.Printf("updated description to \"%s\" for %s\n", description, maskedemail)
 
 
 	default:

--- a/main.go
+++ b/main.go
@@ -12,62 +12,63 @@ import (
 	"github.com/dvcrn/maskedemail-cli/pkg"
 )
 
+type actionType string
+
+const (
+	defaultAppname          string = "maskedemail-cli"
+
+	envTokenVarName 		string = "MASKEDEMAIL_TOKEN"
+	envAppVarName 			string = "MASKEDEMAIL_APPNAME"
+	envAccountIdVarName 	string = "MASKEDEMAIL_ACCOUNTID"
+
+	flagNameEmail			string = "email"
+	flagNameDomain			string = "domain"
+	flagNameDesc			string = "desc"
+	flagNameEnabled			string = "enabled"
+	flagNameShowDeleted		string = "show-deleted"
+
+	actionTypeUnknown		= ""
+	actionTypeCreate        = "create"
+	actionTypeSession       = "session"
+	actionTypeDisable       = "disable"
+	actionTypeEnable        = "enable"
+	actionTypeDelete        = "delete"
+	actionTypeUpdate        = "update"
+	actionTypeList          = "list"
+	actionTypeVersion       = "version"
+
+)
+
 // build info values get passed in from makefile via `-ldflags` argument to `go build`
 //   they only exist if within a git repo, otherwise use defaults below
 // version is based on a git tag "vX.Y.Z" existing
 var buildVersion string = "development"
 var buildCommit string = "n/a"
 
-const envTokenVarName string = "MASKEDEMAIL_TOKEN"
-const envAppVarName string = "MASKEDEMAIL_APPNAME"
-const envAccountIdVarName string = "MASKEDEMAIL_ACCOUNTID"
-
-// common set of flag names that are used in mulitple places
-const flagNameEmail string = "email"
-const flagNameDomain string = "domain"
-const flagNameDesc string = "desc"
-const flagNameEnabled string = "enabled"
-const flagNameShowDeleted string = "show-deleted"
-
 // default / highest level flags
 var flagAppname = flag.String("appname", os.Getenv(envAppVarName), "the appname to identify the creator (or "+envAppVarName+" env) (default: "+defaultAppname+")")
 var flagToken = flag.String("token", "", "the token to authenticate with (or "+envTokenVarName+" env)")
 var flagAccountID = flag.String("accountid", os.Getenv(envAccountIdVarName), "fastmail account id (or "+envAccountIdVarName+" env)")
-var flagVersion = flag.Bool("version", false, "display the version of " + defaultAppname)
+var flagVersion = flag.Bool(actionTypeVersion, false, "display the version of " + defaultAppname)
 
 // flags for list command
-var listCmd = flag.NewFlagSet("list", flag.ExitOnError)
-var flagShowDeleted = listCmd.Bool("show-deleted", false, "show deleted masked emails (true|false) (default false)")
+var listCmd = flag.NewFlagSet(actionTypeList, flag.ExitOnError)
+var flagShowDeleted = listCmd.Bool(flagNameShowDeleted, false, "show deleted masked emails (true|false) (default false)")
 
 // flags for create command
-var createCmd = flag.NewFlagSet("create", flag.ExitOnError)
+var createCmd = flag.NewFlagSet(actionTypeCreate, flag.ExitOnError)
 var flagCreateDomain = createCmd.String(flagNameDomain, "", "domain for the masked email (optional)")
 var flagCreateDescription = createCmd.String(flagNameDesc, "", "description for the masked email (optional)")
 var flagCreateEnabled = createCmd.Bool(flagNameEnabled, true, "is masked email enabled (true|false)")
 
 // flags for update command
-var updateCmd = flag.NewFlagSet("update", flag.ExitOnError)
+var updateCmd = flag.NewFlagSet(actionTypeUpdate, flag.ExitOnError)
 var flagUpdateEmail = updateCmd.String(flagNameEmail, "", "masked email to update (required)")
 var flagUpdateDomain = updateCmd.String(flagNameDomain, "", "domain for the masked email (optional, only updated if argument passed)")
 var flagUpdateDescription = updateCmd.String(flagNameDesc, "", "description for the masked email (optional, only updated if argument passed)")
 
 var action actionType = actionTypeUnknown
 var envToken string
-
-type actionType string
-
-const (
-	actionTypeUnknown            = ""
-	actionTypeCreate             = "create"
-	actionTypeSession            = "session"
-	actionTypeDisable            = "disable"
-	actionTypeEnable             = "enable"
-	actionTypeDelete             = "delete"
-	actionTypeUpdate             = "update"
-	actionTypeList               = "list"
-	actionTypeVersion            = "version"
-	defaultAppname               = "maskedemail-cli"
-)
 
 func isFlagPassed(set flag.FlagSet, name string) bool {
     found := false
@@ -92,11 +93,11 @@ func init() {
 		fmt.Println("Commands:")
 
 		// create
-		fmt.Printf("  %s %s [-%s \"<domain>\"] [-%s \"<description>\"] [-%s=true|false (default: true)]\n",
+		fmt.Printf("  %s %s [-%s \"<domain>\"] [-%s \"<description>\"] [-%s=true|false (default true)]\n",
 					defaultAppname, actionTypeCreate, flagNameDomain, flagNameDesc, flagNameEnabled)
 
 		// list
-		fmt.Printf("  %s %s [-%s (default: false)]\n",
+		fmt.Printf("  %s %s [-%s (default false)]\n",
 					defaultAppname, actionTypeList, flagNameShowDeleted)
 
 		// enable
@@ -137,25 +138,25 @@ func init() {
 
 	switch strings.ToLower(flag.Arg(0)) {
 	case
-		"create":
+		actionTypeCreate:
 		action = actionTypeCreate
 
-	case "session":
+	case actionTypeSession:
 		action = actionTypeSession
 
-	case "disable":
+	case actionTypeDisable:
 		action = actionTypeDisable
 
-	case "enable":
+	case actionTypeEnable:
 		action = actionTypeEnable
 
-	case "delete":
+	case actionTypeDelete:
 		action = actionTypeDelete
 
-	case "list":
+	case actionTypeList:
 		action = actionTypeList
 
-	case "update":
+	case actionTypeUpdate:
 		action = actionTypeUpdate
 	}
 }

--- a/pkg/api.go
+++ b/pkg/api.go
@@ -273,6 +273,30 @@ func (client *Client) DisableMaskedEmail(
 	return client.DisableMaskedEmailByID(session, accID, emailID)
 }
 
+func (client *Client) DeleteMaskedEmailByID(
+	session Session,
+	accID string,
+	emailID string,
+) (*MethodResponseMaskedEmailSet, error) {
+	fields := UpdateFields{ isStateSet: true, state: MaskedEmailStateDeleted };
+	return client.UpdateMaskedEmail(session, accID, emailID, fields)
+}
+
+func (client *Client) DeleteMaskedEmail(
+	session Session,
+	accID string,
+	email string,
+) (*MethodResponseMaskedEmailSet, error) {
+
+	emailID, err := client.LookupMaskedEmailID(session, accID, email)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return client.DeleteMaskedEmailByID(session, accID, emailID)
+}
+
 func (client *Client) UpdateMaskedEmail(
 	session Session,
 	accID string,

--- a/pkg/api.go
+++ b/pkg/api.go
@@ -145,6 +145,7 @@ func (client *Client) CreateMaskedEmail(
 	accID string,
 	forDomain string,
 	enabled bool,
+	description string,
 ) (*MaskedEmail, error) {
 	state := ""
 	if enabled {
@@ -158,7 +159,7 @@ func (client *Client) CreateMaskedEmail(
 
 	mc := MethodCall{
 		MethodName: "MaskedEmail/set",
-		Payload:    NewMethodCallCreate(accID, client.appName, forDomain, state),
+		Payload:    NewMethodCallCreate(accID, client.appName, forDomain, state, description),
 		Payload2:   "0",
 	}
 

--- a/pkg/api.go
+++ b/pkg/api.go
@@ -44,8 +44,8 @@ type Session interface {
 type UpdateFields struct {
 	isStateSet	     bool
 	state            MaskedEmailState
-	isForDomainSet   bool
-	forDomain        string
+	isDomainSet      bool
+	domain           string
 	isDescriptionSet bool
 	description      string
 }
@@ -143,7 +143,7 @@ func (client *Client) accIDOrDefault(session Session, accID string) (string, err
 	return accID, nil
 }
 
-// CreateMaskedEmail creates a new masked email for the given forDomain domain.
+// CreateMaskedEmail creates a new masked email for the given domain.
 //
 // If `accID` is the empty string, the primary account for Masked Email will be
 // used.
@@ -152,7 +152,7 @@ func (client *Client) accIDOrDefault(session Session, accID string) (string, err
 func (client *Client) CreateMaskedEmail(
 	session Session,
 	accID string,
-	forDomain string,
+	domain string,
 	enabled bool,
 	description string,
 ) (*MaskedEmail, error) {
@@ -168,7 +168,7 @@ func (client *Client) CreateMaskedEmail(
 
 	mc := MethodCall{
 		MethodName: "MaskedEmail/set",
-		Payload:    NewMethodCallCreate(accID, client.appName, forDomain, state, description),
+		Payload:    NewMethodCallCreate(accID, client.appName, domain, state, description),
 		Payload2:   "0",
 	}
 
@@ -289,8 +289,8 @@ func (client *Client) UpdateMaskedEmail(
 	var payload MethodCallUpdate
 	 if fields.isStateSet {
 	 	payload = NewMethodCallUpdateState(accID, emailID, fields.state)
-	 } else if fields.isForDomainSet {
-	 	payload = NewMethodCallUpdateForDomain(accID, emailID, fields.forDomain)
+	 } else if fields.isDomainSet {
+	 	payload = NewMethodCallUpdateDomain(accID, emailID, fields.domain)
 	 } else if fields.isDescriptionSet {
 	 	payload = NewMethodCallUpdateDescription(accID, emailID, fields.description)
 	 }
@@ -326,21 +326,21 @@ func (client *Client) UpdateMaskedEmail(
 	return nil, nil
 }
 
-func (client *Client) UpdateForDomainByID(
+func (client *Client) UpdateDomainByID(
 	session Session,
 	accID string,
 	emailID string,
-	forDomain string,
+	domain string,
 ) (*MethodResponseMaskedEmailSet, error) {
-	fields := UpdateFields{ isForDomainSet: true, forDomain: forDomain };
+	fields := UpdateFields{ isDomainSet: true, domain: domain };
 	return client.UpdateMaskedEmail(session, accID, emailID, fields)
 }
 
-func (client *Client) UpdateForDomain(
+func (client *Client) UpdateDomain(
 	session Session,
 	accID string,
 	email string,
-	forDomain string,
+	domain string,
 ) (*MethodResponseMaskedEmailSet, error) {
 
 	emailID, err := client.LookupMaskedEmailID(session, accID, email)
@@ -349,7 +349,7 @@ func (client *Client) UpdateForDomain(
 		return nil, err
 	}
 
-	return client.UpdateForDomainByID(session, accID, emailID, forDomain)
+	return client.UpdateDomainByID(session, accID, emailID, domain)
 }
 
 func (client *Client) UpdateDescriptionByID(

--- a/pkg/requests.go
+++ b/pkg/requests.go
@@ -59,8 +59,8 @@ type MethodCallCreate struct {
 }
 
 type UpdatePayload struct {
-	State string `json:"state,omitempty"`
-	Domain string `json:"forDomain,omitempty"`
+	State       string `json:"state,omitempty"`
+	Domain      string `json:"forDomain,omitempty"`
 	Description string `json:"description,omitempty"`
 }
 
@@ -92,59 +92,48 @@ const (
 )
 
 type MethodCallUpdate struct {
-	AccountID string                 `json:"accountId,omitempty"`
+	AccountID string                   `json:"accountId,omitempty"`
 	Update    map[string]UpdatePayload `json:"update,omitempty"`
 }
 
-// NewMethodCallUpdateState creates a new method call to update a maskedemail.
-// This is for example used when a temporary email is converted into a finalized one.
-func NewMethodCallUpdateState(accID, alias string, state MaskedEmailState) MethodCallUpdate {
+// NewMethodCallUpdate creates a new method call to update a maskedemail.
+func NewMethodCallUpdate(accID, alias string, fields *UpdateFields) MethodCallUpdate {
 	mesp := MethodCallUpdate{}
 	mesp.AccountID = accID
+
+  var state MaskedEmailState = "";
+	if fields.isStateSet {
+		state = fields.state
+	}
+
+  var domain string = "";
+	if fields.isDomainSet {
+		// HACK: to make it appear the value is cleared out, set to a single space
+		//  if left as empty string, the conversion to json's
+		//  omitempty will not pass value in request and it won't get changed
+		if fields.domain == "" {
+			domain = " "
+		} else {
+			domain = fields.domain
+		}
+	}
+
+	var description string = "";
+	if fields.isDescriptionSet {
+		// HACK: to make it appear the value is cleared out, set to a single space
+		//  if left as empty string, the conversion to json's
+		//  omitempty will not pass value in request and it won't get changed
+		if fields.description == "" {
+			description = " "
+		} else {
+			description = fields.description
+		}
+	}
+
 	mesp.Update = map[string]UpdatePayload{
 		alias: {
 			State: string(state),
-		},
-	}
-
-	return mesp
-}
-
-// NewMethodCallUpdateDomain creates a new method call to update a maskedemail.
-func NewMethodCallUpdateDomain(accID, alias string, domain string) MethodCallUpdate {
-	mesp := MethodCallUpdate{}
-	mesp.AccountID = accID
-
-	// HACK: to make it appear the value is cleared out
-	//  if left as empty string, the conversion to json's
-	//  omitempty will not pass value in request and it won't get changed
-	if domain == "" {
-		domain = " "
-	}
-
-	mesp.Update = map[string]UpdatePayload{
-		alias: {
 			Domain: string(domain),
-		},
-	}
-
-	return mesp
-}
-
-// NewMethodCallUpdateDescription creates a new method call to update a maskedemail.
-func NewMethodCallUpdateDescription(accID, alias string, description string) MethodCallUpdate {
-	mesp := MethodCallUpdate{}
-	mesp.AccountID = accID
-
-	// HACK: to make it appear the value is cleared out
-	//  if left as empty string, the conversion to json's
-	//  omitempty will not pass value in request and it won't get changed
-	if description == "" {
-		description = " "
-	}
-
-	mesp.Update = map[string]UpdatePayload{
-		alias: {
 			Description: string(description),
 		},
 	}

--- a/pkg/requests.go
+++ b/pkg/requests.go
@@ -48,8 +48,9 @@ func (r *MethodCall) MarshalJSON() ([]byte, error) {
 */
 
 type CreatePayload struct {
-	ForDomain string `json:"forDomain"`
-	State     string `json:"state,omitempty"`
+	ForDomain   string `json:"forDomain"`
+	State       string `json:"state,omitempty"`
+	Description string `json:"description"`
 }
 
 type MethodCallCreate struct {
@@ -65,13 +66,14 @@ type UpdateState struct {
 // accID is the users account ID.
 // appName is the name to identify the app that created the maskedemail.
 // domain is the label to identify where the email is intended for.
-func NewMethodCallCreate(accID, appName, domain string, state string) MethodCallCreate {
+func NewMethodCallCreate(accID, appName, domain string, state string, description string) MethodCallCreate {
 	mesp := MethodCallCreate{}
 	mesp.AccountID = accID
 	mesp.Create = map[string]CreatePayload{
 		appName: {
-			ForDomain: domain,
-			State:     state,
+			ForDomain:   domain,
+			State:       state,
+			Description: description,
 		},
 	}
 

--- a/pkg/requests.go
+++ b/pkg/requests.go
@@ -48,7 +48,7 @@ func (r *MethodCall) MarshalJSON() ([]byte, error) {
 */
 
 type CreatePayload struct {
-	ForDomain   string `json:"forDomain"`
+	Domain      string `json:"forDomain"`
 	State       string `json:"state,omitempty"`
 	Description string `json:"description"`
 }
@@ -60,7 +60,7 @@ type MethodCallCreate struct {
 
 type UpdatePayload struct {
 	State string `json:"state,omitempty"`
-	ForDomain string `json:"forDomain,omitempty"`
+	Domain string `json:"forDomain,omitempty"`
 	Description string `json:"description,omitempty"`
 }
 
@@ -69,12 +69,12 @@ type UpdatePayload struct {
 // appName is the name to identify the app that created the maskedemail.
 // domain is the label to identify where the email is intended for.
 // description is a description of the masked email
-func NewMethodCallCreate(accID, appName, forDomain string, state string, description string) MethodCallCreate {
+func NewMethodCallCreate(accID, appName, domain string, state string, description string) MethodCallCreate {
 	mesp := MethodCallCreate{}
 	mesp.AccountID = accID
 	mesp.Create = map[string]CreatePayload{
 		appName: {
-			ForDomain:   forDomain,
+			Domain:      domain,
 			State:       state,
 			Description: description,
 		},
@@ -110,20 +110,20 @@ func NewMethodCallUpdateState(accID, alias string, state MaskedEmailState) Metho
 }
 
 // NewMethodCallUpdateDomain creates a new method call to update a maskedemail.
-func NewMethodCallUpdateForDomain(accID, alias string, forDomain string) MethodCallUpdate {
+func NewMethodCallUpdateDomain(accID, alias string, domain string) MethodCallUpdate {
 	mesp := MethodCallUpdate{}
 	mesp.AccountID = accID
 
 	// HACK: to make it appear the value is cleared out
 	//  if left as empty string, the conversion to json's
 	//  omitempty will not pass value in request and it won't get changed
-	if forDomain == "" {
-		forDomain = " "
+	if domain == "" {
+		domain = " "
 	}
 
 	mesp.Update = map[string]UpdatePayload{
 		alias: {
-			ForDomain: string(forDomain),
+			Domain: string(domain),
 		},
 	}
 

--- a/pkg/requests.go
+++ b/pkg/requests.go
@@ -58,20 +58,23 @@ type MethodCallCreate struct {
 	Create    map[string]CreatePayload `json:"create,omitempty"`
 }
 
-type UpdateState struct {
+type UpdatePayload struct {
 	State string `json:"state,omitempty"`
+	ForDomain string `json:"forDomain,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 // NewMethodCallCreate creates a new method call to create a new maskedemail.
 // accID is the users account ID.
 // appName is the name to identify the app that created the maskedemail.
 // domain is the label to identify where the email is intended for.
-func NewMethodCallCreate(accID, appName, domain string, state string, description string) MethodCallCreate {
+// description is a description of the masked email
+func NewMethodCallCreate(accID, appName, forDomain string, state string, description string) MethodCallCreate {
 	mesp := MethodCallCreate{}
 	mesp.AccountID = accID
 	mesp.Create = map[string]CreatePayload{
 		appName: {
-			ForDomain:   domain,
+			ForDomain:   forDomain,
 			State:       state,
 			Description: description,
 		},
@@ -89,7 +92,7 @@ const (
 
 type MethodCallUpdate struct {
 	AccountID string                 `json:"accountId,omitempty"`
-	Update    map[string]UpdateState `json:"update,omitempty"`
+	Update    map[string]UpdatePayload `json:"update,omitempty"`
 }
 
 // NewMethodCallUpdateState creates a new method call to update a maskedemail.
@@ -97,9 +100,51 @@ type MethodCallUpdate struct {
 func NewMethodCallUpdateState(accID, alias string, state MaskedEmailState) MethodCallUpdate {
 	mesp := MethodCallUpdate{}
 	mesp.AccountID = accID
-	mesp.Update = map[string]UpdateState{
+	mesp.Update = map[string]UpdatePayload{
 		alias: {
 			State: string(state),
+		},
+	}
+
+	return mesp
+}
+
+// NewMethodCallUpdateDomain creates a new method call to update a maskedemail.
+func NewMethodCallUpdateForDomain(accID, alias string, forDomain string) MethodCallUpdate {
+	mesp := MethodCallUpdate{}
+	mesp.AccountID = accID
+
+	// HACK: to make it appear the value is cleared out
+	//  if left as empty string, the conversion to json's
+	//  omitempty will not pass value in request and it won't get changed
+	if forDomain == "" {
+		forDomain = " "
+	}
+
+	mesp.Update = map[string]UpdatePayload{
+		alias: {
+			ForDomain: string(forDomain),
+		},
+	}
+
+	return mesp
+}
+
+// NewMethodCallUpdateDescription creates a new method call to update a maskedemail.
+func NewMethodCallUpdateDescription(accID, alias string, description string) MethodCallUpdate {
+	mesp := MethodCallUpdate{}
+	mesp.AccountID = accID
+
+	// HACK: to make it appear the value is cleared out
+	//  if left as empty string, the conversion to json's
+	//  omitempty will not pass value in request and it won't get changed
+	if description == "" {
+		description = " "
+	}
+
+	mesp.Update = map[string]UpdatePayload{
+		alias: {
+			Description: string(description),
 		},
 	}
 

--- a/pkg/requests.go
+++ b/pkg/requests.go
@@ -88,6 +88,7 @@ type MaskedEmailState string
 const (
 	MaskedEmailStateEnabled  MaskedEmailState = "enabled"
 	MaskedEmailStateDisabled                  = "disabled"
+	MaskedEmailStateDeleted                   = "deleted"
 )
 
 type MethodCallUpdate struct {

--- a/pkg/requests.go
+++ b/pkg/requests.go
@@ -142,6 +142,7 @@ func NewMethodCallUpdate(accID, alias string, fields *UpdateFields) MethodCallUp
 }
 
 // MethodCallGetAll is a method call to get all maskedemails for a user.
+/*
 // Request:
 //    "methodCalls" : [
 //      [
@@ -177,6 +178,7 @@ func NewMethodCallUpdate(accID, alias string, fields *UpdateFields) MethodCallUp
 //      ]
 //   ]
 //
+*/
 type MethodCallGetAll struct {
 	AccountID string `json:"accountId,omitempty"`
 }

--- a/pkg/responses.go
+++ b/pkg/responses.go
@@ -47,7 +47,7 @@ type MaskedEmail struct {
 	LastMessageAt string `mapstructure:"lastMessageAt" json:"lastMessageAt"`
 	State         string `mapstructure:"state" json:"state"`
 	URL           string `mapstructure:"url" json:"url"`
-	ForDomain     string `mapstructure:"forDomain" json:"forDomain"`
+	Domain        string `mapstructure:"forDomain" json:"forDomain"`
 }
 
 type MethodResponseMaskedEmailSet struct {


### PR DESCRIPTION
Hi, I noticed there was some masked email functionality missing from the CLI (description, delete), so I took a stab at adding them, and ended up doing a bit more than that (I tried to clean things up/refactor a bit to what made more sense *to me*).  It's mostly the same, but not entirely backwards compatible (some command arguments I changed around to convert positional args to named), so I called this v2.0.0.  This was my first go at... go, was a bit of fun, but I tried not to mess with any of the more involved parts.  

There was only one area that was a bit of a hack, for clearing out a domain/description, it sets it to a single space, otherwise it'd never get passed (due to the `omitempty`, but I wanted to keep that in (the space gets stripped when displaying though, so it appears empty to user).  

If you don't want any of the changes, no worries!  I've got an [Alfred](https://www.alfredapp.com) (for Mac) workflow to put up soon as well that uses this new version for quick access to just about all the features.  

Here's the updated help/usage as an overview:
```
Usage of ./maskedemail-cli:
Flags:
  -accountid string
    	fastmail account id (or MASKEDEMAIL_ACCOUNTID env)
  -appname string
    	the appname to identify the creator (or MASKEDEMAIL_APPNAME env) (default: maskedemail-cli)
  -token string
    	the token to authenticate with (or MASKEDEMAIL_TOKEN env)
  -version
    	display the version of maskedemail-cli

Commands:
  maskedemail-cli create [-domain "<domain>"] [-desc "<description>"] [-enabled=true|false (default true)]
  maskedemail-cli list [-show-deleted] [-all-fields]
  maskedemail-cli enable <maskedemail>
  maskedemail-cli disable <maskedemail>
  maskedemail-cli delete <maskedemail>
  maskedemail-cli update -email <maskedemail> [-domain "<domain>"] [-desc "<description>"]
  maskedemail-cli session
```