### PR TITLE
Add `-prefix` flag to specify optional `emailPrefix`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Flags:
       the token to authenticate with (or MASKEDEMAIL_TOKEN env)
 
 Commands:
-  maskedemail-cli create [-domain "<domain>"] [-desc "<description>"] [-enabled=true|false (default true)]
+  maskedemail-cli create [-domain "<domain>"] [-desc "<description>"] [-prefix "<prefix>"] [-enabled=true|false (default true)]
   maskedemail-cli list [-show-deleted] [-all-fields]
   maskedemail-cli enable <maskedemail>
   maskedemail-cli disable <maskedemail>

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ const (
 	flagNameEmail         string = "email"
 	flagNameDomain        string = "domain"
 	flagNameDesc          string = "desc"
+	flagNamePrefix        string = "prefix"
 	flagNameEnabled       string = "enabled"
 	flagNameShowDeleted   string = "show-deleted"
 	flagNameShowAllFields string = "all-fields"
@@ -64,6 +65,7 @@ var flagShowAllFields = listCmd.Bool(flagNameShowAllFields, false, "show all mas
 var createCmd = flag.NewFlagSet(actionTypeCreate, flag.ExitOnError)
 var flagCreateDomain = createCmd.String(flagNameDomain, "", "domain for the masked email (optional)")
 var flagCreateDescription = createCmd.String(flagNameDesc, "", "description for the masked email (optional)")
+var flagCreateEmailPrefix = createCmd.String(flagNamePrefix, "", "prefix for the masked email (optional)")
 var flagCreateEnabled = createCmd.Bool(flagNameEnabled, true, "is masked email enabled (true|false)")
 
 // flags for update command
@@ -103,8 +105,8 @@ func init() {
 		fmt.Println("Commands:")
 
 		// create
-		fmt.Printf("  %s %s [-%s \"<domain>\"] [-%s \"<description>\"] [-%s=true|false (default true)]\n",
-			defaultAppname, actionTypeCreate, flagNameDomain, flagNameDesc, flagNameEnabled)
+		fmt.Printf("  %s %s [-%s \"<domain>\"] [-%s \"<description>\"] [-%s \"<prefix>\"] [-%s=true|false (default true)]\n",
+			defaultAppname, actionTypeCreate, flagNameDomain, flagNameDesc, flagNamePrefix, flagNameEnabled)
 
 		// list
 		fmt.Printf("  %s %s [-%s] [-%s]\n",
@@ -238,13 +240,14 @@ func main() {
 
 		domain := strings.TrimSpace(*flagCreateDomain)
 		description := strings.TrimSpace(*flagCreateDescription)
+		emailPrefix := strings.TrimSpace(*flagCreateEmailPrefix)
 
 		session, err := client.Session()
 		if err != nil {
 			log.Fatalf("initializing session: %v", err)
 		}
 
-		createRes, err := client.CreateMaskedEmail(session, *flagAccountID, domain, *flagCreateEnabled, description)
+		createRes, err := client.CreateMaskedEmail(session, *flagAccountID, domain, *flagCreateEnabled, description, emailPrefix)
 		if err != nil {
 			log.Fatalf("error creating masked email: %v", err)
 		}

--- a/pkg/api.go
+++ b/pkg/api.go
@@ -146,6 +146,7 @@ func (client *Client) CreateMaskedEmail(
 	domain string,
 	enabled bool,
 	description string,
+	emailPrefix string,
 ) (*MaskedEmail, error) {
 	state := ""
 	if enabled {
@@ -159,7 +160,7 @@ func (client *Client) CreateMaskedEmail(
 
 	mc := MethodCall{
 		MethodName: "MaskedEmail/set",
-		Payload:    NewMethodCallCreate(accID, client.appName, domain, state, description),
+		Payload:    NewMethodCallCreate(accID, client.appName, domain, state, description, emailPrefix),
 		Payload2:   "0",
 	}
 

--- a/pkg/requests.go
+++ b/pkg/requests.go
@@ -59,6 +59,7 @@ type CreatePayload struct {
 	Domain      string `json:"forDomain"`
 	State       string `json:"state,omitempty"`
 	Description string `json:"description"`
+	EmailPrefix string `json:"emailPrefix"`
 }
 
 type MethodCallCreate struct {
@@ -103,7 +104,8 @@ func WithUpdateDescription(desc string) UpdateOption {
 // appName is the name to identify the app that created the maskedemail.
 // domain is the label to identify where the email is intended for.
 // description is a description of the masked email
-func NewMethodCallCreate(accID, appName, domain string, state string, description string) MethodCallCreate {
+// emailPrefix is the prefix for the masked email
+func NewMethodCallCreate(accID, appName, domain string, state string, description string, emailPrefix string) MethodCallCreate {
 	mesp := MethodCallCreate{}
 	mesp.AccountID = accID
 	mesp.Create = map[string]CreatePayload{
@@ -111,6 +113,7 @@ func NewMethodCallCreate(accID, appName, domain string, state string, descriptio
 			Domain:      domain,
 			State:       state,
 			Description: description,
+			EmailPrefix: emailPrefix,
 		},
 	}
 


### PR DESCRIPTION
From https://www.fastmail.com/for-developers/masked-email/#object:

> **emailPrefix**: `String` (create-only) This is only used on create and otherwise ignored; it is not returned when MaskedEmail objects are fetched. If supplied, the server-assigned email will start with the given prefix. The string MUST be <= 64 characters in length and MUST only contain characters a-z, 0-9 and _ (underscore).

I have not implemented any checks whether the prefix meets the requirements above. The API returns an error and does not create a masked email if the prefix does not meet the requirements.