### PR TITLE
Align release flow and npm scripts with wework-cli reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up mise
+        uses: jdx/mise-action@v2
+
+      - name: Run tests
+        run: mise run test
+
+      - name: Build
+        run: mise run build

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,8 @@ builds:
     ignore:
       - goos: windows
         goarch: arm
+      - goos: darwin
+        goarch: arm
     flags:
       - -trimpath
       - -buildvcs=false

--- a/mise.development.toml
+++ b/mise.development.toml
@@ -11,4 +11,4 @@ run = "goreleaser release --clean --config .goreleaser.yml"
 
 [tasks.release]
 description = "Alias for goreleaser_release"
-run = "mise run goreleaser_release"
+depends = ["goreleaser_release"]

--- a/mise.development.toml
+++ b/mise.development.toml
@@ -1,24 +1,5 @@
 [tools]
-go = "1.18"
-node = "20"
-
-[tasks.fix]
-description = "Auto-applies Golang fixes"
-run = "go fix ./..."
-
-[tasks.format]
-description = "Run go fix, then format Go code"
-depends = ["fix"]
-run = "go fmt ./..."
-
-[tasks.build]
-description = "Build the application binary"
-depends = ["fix"]
-run = "go build -o maskedemail-cli ."
-
-[tasks.test]
-description = "Run all tests"
-run = "go test ./..."
+goreleaser = "2.13.3"
 
 [tasks.goreleaser_snapshot]
 description = "Build CLI artifacts via GoReleaser (snapshot)"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,34 @@
+[tools]
+go = "1.18"
+goreleaser = "2.13.3"
+node = "20"
+
+[tasks.fix]
+description = "Auto-applies Golang fixes"
+run = "go fix ./..."
+
+[tasks.format]
+description = "Run go fix, then format code with goimports"
+depends = ["fix"]
+run = 'find . -name "*.go" -type f -exec go tool goimports -w {} +'
+
+[tasks.build]
+description = "Build the application binary"
+depends = ["fix"]
+run = "go build -o maskedemail-cli ."
+
+[tasks.test]
+description = "Run all tests"
+run = "go test ./..."
+
+[tasks.goreleaser_snapshot]
+description = "Build CLI artifacts via GoReleaser (snapshot)"
+run = "goreleaser release --snapshot --clean --config .goreleaser.yml"
+
+[tasks.goreleaser_release]
+description = "Publish GitHub Release via GoReleaser"
+run = "goreleaser release --clean --config .goreleaser.yml"
+
+[tasks.release]
+description = "Alias for goreleaser_release"
+run = "mise run goreleaser_release"

--- a/mise.toml
+++ b/mise.toml
@@ -8,9 +8,9 @@ description = "Auto-applies Golang fixes"
 run = "go fix ./..."
 
 [tasks.format]
-description = "Run go fix, then format code with goimports"
+description = "Run go fix, then format Go code"
 depends = ["fix"]
-run = 'find . -name "*.go" -type f -exec go tool goimports -w {} +'
+run = "go fmt ./..."
 
 [tasks.build]
 description = "Build the application binary"

--- a/npm/index.js
+++ b/npm/index.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 const path = require("path");
 const { spawn } = require("child_process");
 
-const { ensureInstalled } = require("./postinstall");
+const { installBinary } = require("./postinstall");
 const { startUpdateCheck } = require("./update_check");
 
 const exe = process.platform === "win32" ? "maskedemail-cli.exe" : "maskedemail-cli";
@@ -22,7 +22,7 @@ const PKG = (() => {
     if (!fs.existsSync(binPath)) {
       console.error(`Binary not found: ${binPath}`);
       console.error("Attempting to download it now...");
-      await ensureInstalled();
+      await installBinary();
     }
 
     if (!fs.existsSync(binPath)) {

--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -146,7 +146,7 @@ function ensureExecutable(binPath) {
   }
 }
 
-async function ensureInstalled({ log = console.log } = {}) {
+async function installBinary({ log = console.log } = {}) {
   if (isTruthyEnv(SKIP_POSTINSTALL_ENV)) {
     log(`postinstall: skipping binary download because ${SKIP_POSTINSTALL_ENV} is set`);
     return null;
@@ -207,7 +207,7 @@ async function ensureInstalled({ log = console.log } = {}) {
 
 async function main() {
   try {
-    await ensureInstalled();
+    await installBinary();
   } catch (err) {
     console.error(`postinstall error: ${err.message}`);
     process.exit(1);
@@ -219,6 +219,6 @@ if (require.main === module) {
 }
 
 module.exports = {
-  ensureInstalled,
+  installBinary,
   getTargetInfo,
 };


### PR DESCRIPTION
## Summary

- Add `mise.toml` with `goreleaser`/`node` tools and standard tasks (`fix`, `format`, `build`, `test`, `goreleaser_snapshot`, `goreleaser_release`, `release`)
- Add `.github/workflows/ci.yml` for CI using mise
- Rename `ensureInstalled` → `installBinary` in `postinstall.js` and `index.js` to match wework-cli convention